### PR TITLE
Support inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Albelli.Templates.Amazon
 
-
-<a href="https://ci.appveyor.com/project/albumprinter/albelli-templates-amazon/branch/master"><img src="https://ci.appveyor.com/api/projects/status/bunen2a3k2rlt7dp?svg=true" />
-</a> <a href="https://www.nuget.org/packages/Albelli.Templates.Amazon/"><img src="https://img.shields.io/nuget/vpre/Albelli.Templates.Amazon.svg" /></a>
+<a href="https://ci.appveyor.com/project/albumprinter/albelli-templates-amazon/branch/master"><img src="https://ci.appveyor.com/api/projects/status/bunen2a3k2rlt7dp?svg=true" /></a>
+<a href="https://www.nuget.org/packages/Albelli.Templates.Amazon/"><img src="https://img.shields.io/nuget/vpre/Albelli.Templates.Amazon.svg" /></a>
 
 ## Overview
 

--- a/src/Albelli.Templates.Amazon.Core/Handlers/SingleItemFunction.cs
+++ b/src/Albelli.Templates.Amazon.Core/Handlers/SingleItemFunction.cs
@@ -37,6 +37,11 @@ namespace Albelli.Templates.Amazon.Core.Handlers
 
         protected abstract string GetEntityJson(TItem item);
 
+        /// <summary>
+        /// If you have inheritance with TEntity type and want to handle descendants, you could describe type choosing logic in this method
+        /// </summary>
+        protected virtual Type GetEntityType(TItem item) => typeof(TEntity);
+
         protected void ConfigureMessageRouter<TMessageRouter>()
         where TMessageRouter : class, IMessageRouter
         {
@@ -61,7 +66,7 @@ namespace Albelli.Templates.Amazon.Core.Handlers
             requestFeatures.Method = "POST";
 
             var messageRouter = _serviceProvider.GetService<IMessageRouter>();
-            var path = $"/{messageRouter.GetPath<TEntity>().Trim('/')}/";
+            var path = $"/{messageRouter.GetPath(GetEntityType(item)).Trim('/')}/";
 
             requestFeatures.Path = path;
             requestFeatures.PathBase = string.Empty;

--- a/src/Albelli.Templates.Amazon.Core/Routing/BodyTypeMessageRouter.cs
+++ b/src/Albelli.Templates.Amazon.Core/Routing/BodyTypeMessageRouter.cs
@@ -33,9 +33,8 @@ namespace Albelli.Templates.Amazon.Core.Routing
             return this;
         }
 
-        public string GetPath<TEntity>()
+        public string GetPath(Type type)
         {
-            var type = typeof(TEntity);
             if (_entityToPathCustomMap.ContainsKey(type))
             {
                 return _entityToPathCustomMap[type];

--- a/src/Albelli.Templates.Amazon.Core/Routing/IMessageRouter.cs
+++ b/src/Albelli.Templates.Amazon.Core/Routing/IMessageRouter.cs
@@ -1,8 +1,10 @@
-﻿namespace Albelli.Templates.Amazon.Core.Routing
+﻿using System;
+
+namespace Albelli.Templates.Amazon.Core.Routing
 {
     public interface IMessageRouter
     {
         IMessageRouter AddMapping<TEntity>(string path);
-        string GetPath<TEntity>();
+        string GetPath(Type type);
     }
 }

--- a/templates/content/SnsLambda/src/Albelli.Templates.Amazon.Sns.Lambda/Albelli.Templates.Amazon.Sns.Lambda.csproj
+++ b/templates/content/SnsLambda/src/Albelli.Templates.Amazon.Sns.Lambda/Albelli.Templates.Amazon.Sns.Lambda.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-    <PackageReference Include="Albelli.Templates.Amazon.Core.Sns" Version="0.2.1-b0001" />
+    <PackageReference Include="Albelli.Templates.Amazon.Core.Sns" Version="0.3.1" />
   </ItemGroup>
   
 </Project>

--- a/templates/content/SqsLambda/src/Albelli.Templates.Amazon.Sqs.Lambda/Albelli.Templates.Amazon.Sqs.Lambda.csproj
+++ b/templates/content/SqsLambda/src/Albelli.Templates.Amazon.Sqs.Lambda/Albelli.Templates.Amazon.Sqs.Lambda.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-    <PackageReference Include="Albelli.Templates.Amazon.Core.Sqs" Version="0.2.1-b0001" />
+    <PackageReference Include="Albelli.Templates.Amazon.Core.Sqs" Version="0.3.1" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Sometimes we want to handle multiple contracts with one lambda. The purpose of this PR — provide this feature.

Proposed changes:
- Add `GetEntityType` method to be able to specify descenders and their handlers based on event data