### PR TITLE
Throw exception when request failed in ASP.NET Core layer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2019
 build_script:
-  - ps: .\build.ps1 -Target Push
+  - cmd: build.cmd -t Push
 test: off
 skip_branch_with_pr: true
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2019
 build_script:
-  - cmd: build.cmd -t Push
+  - ps: .\build.ps1 -Target Push
 test: off
 skip_branch_with_pr: true
 nuget:

--- a/src/Albelli.Templates.Amazon.Core/Handlers/LambdaHandlingException.cs
+++ b/src/Albelli.Templates.Amazon.Core/Handlers/LambdaHandlingException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Albelli.Templates.Amazon.Core.Handlers
+{
+    public class LambdaHandlingException : Exception
+    {
+        public LambdaHandlingException(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/src/Albelli.Templates.Amazon.Core/Handlers/SingleItemFunction.cs
+++ b/src/Albelli.Templates.Amazon.Core/Handlers/SingleItemFunction.cs
@@ -103,6 +103,13 @@ namespace Albelli.Templates.Amazon.Core.Handlers
             SingleItemPipelineHandlers.ForeachReverse(handler => handler.HookAfter(item, lambdaContext));
 
             lambdaContext.Logger.Log($"{typeof(TItem)} handled with status: {response.StatusCode}");
+            var statusCode = (int)response.StatusCode;
+            if (statusCode >= 200 && statusCode <= 299)
+            {
+                return;
+            }
+
+            throw new LambdaHandlingException($"{typeof(TItem)} handling failed with StatusCode {statusCode}");
         }
 
         public List<IPipelineHandler<TItem>> SingleItemPipelineHandlers { get; } = new List<IPipelineHandler<TItem>>();


### PR DESCRIPTION
Lambda should re-throw an exception from ASP.NET Core layer. Otherwise, the request will be treated as completed whereas we expect to see it in the DLQ.

Proposed changes:
- Throw an exception if `StatusCode` is not successful