### PR TITLE
Raise templates to the new version

### DIFF
--- a/templates/content/SnsLambda/src/Albelli.Templates.Amazon.Sns.Lambda/Albelli.Templates.Amazon.Sns.Lambda.csproj
+++ b/templates/content/SnsLambda/src/Albelli.Templates.Amazon.Sns.Lambda/Albelli.Templates.Amazon.Sns.Lambda.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-    <PackageReference Include="Albelli.Templates.Amazon.Core.Sns" Version="0.3.1" />
+    <PackageReference Include="Albelli.Templates.Amazon.Core.Sns" Version="0.4.2" />
   </ItemGroup>
   
 </Project>

--- a/templates/content/SqsLambda/src/Albelli.Templates.Amazon.Sqs.Lambda/Albelli.Templates.Amazon.Sqs.Lambda.csproj
+++ b/templates/content/SqsLambda/src/Albelli.Templates.Amazon.Sqs.Lambda/Albelli.Templates.Amazon.Sqs.Lambda.csproj
@@ -20,5 +20,4 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="Albelli.Templates.Amazon.Core.Sqs" Version="0.4.2" />
   </ItemGroup>
-  
 </Project>

--- a/templates/content/SqsLambda/src/Albelli.Templates.Amazon.Sqs.Lambda/Albelli.Templates.Amazon.Sqs.Lambda.csproj
+++ b/templates/content/SqsLambda/src/Albelli.Templates.Amazon.Sqs.Lambda/Albelli.Templates.Amazon.Sqs.Lambda.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-    <PackageReference Include="Albelli.Templates.Amazon.Core.Sqs" Version="0.3.1" />
+    <PackageReference Include="Albelli.Templates.Amazon.Core.Sqs" Version="0.4.2" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Since templates depend on NuGet packages they should be updated after the main release.

Related PR:  #3